### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # SHARE to VIVO Commmand Line Interface
 
-##Installation
+## Installation
 ```{r, engine='bash', count_lines}
 pip install -r requirements.txt
 ```
 
-##Running share2vivo
+## Running share2vivo
 ```{r, engine='bash', count_lines}
 python share2vivo.py --authnames "Leyla Garcia|Garcia, Leyla"
 ```
@@ -13,7 +13,7 @@ python share2vivo.py --authnames "Leyla Garcia|Garcia, Leyla"
 python share2vivo.py --csv ./tests/test.csv --output ./tests/
 ```
 
-##More information
+## More information
 ```{r, engine='bash', count_lines}
 python share2vivo.py --help
 ```


### PR DESCRIPTION
Markdown needs a space between the ## and text to indicate  a second level header for proper display.